### PR TITLE
Fix typo in services.md

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -420,7 +420,7 @@ jobs:
 pingme pushbullet \
   --sms true \
   --token "abcdefg" \
-  -d "adnroid" \
+  -d "android" \
   --msg "some message" \
   --number "00123456789"
 ```
@@ -428,7 +428,7 @@ pingme pushbullet \
 - Push notification
 
 ```bash
-pingme pushbullet --token "abcdefg" -d "adnroid" --msg "some message"
+pingme pushbullet --token "abcdefg" -d "android" --msg "some message"
 ```
 
 - GitHub Action


### PR DESCRIPTION
# Description

Fixes typo from `adnroid` to `android`